### PR TITLE
Adding label renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,7 @@
   "commitBodyTable": true,
   "ignorePaths": ["archive/**"],
   "suppressNotifications": ["prIgnoreNotification"],
+  "labels": ["renovate"],
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
Added the "labels": ["renovate"] configuration to our renovate.json file to ensure that every pull request opened by Renovate is automatically tagged with the "renovate" label.