### PR TITLE
feat: add wait for GL package CR readiness

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -19,3 +19,14 @@ components:
         version: "8.0.1"
         valuesFiles:
           - ../values/common-values.yaml
+    actions:
+      onDeploy:
+        after:
+          - description: Validate GitLab Package
+            maxTotalSeconds: 300
+            wait:
+              cluster:
+                kind: Packages
+                name: gitlab
+                namespace: gitlab
+                condition: "'{.status.phase}'=Ready"


### PR DESCRIPTION
## Description

Adds a wait action for the GL package CR. This is consistent with the pattern in uds-core however it runs _after_ the GitLab chart installs (meaning the GitLab chart may still fail waiting on resources like secrets to exist) however this will catch other issues such as failed updates to resources or missing resources the chart doesn't directly depend on like netpols.

## Related Issue

Fixes #140 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
