### PR TITLE
feat: allow for Postgres password secret generation

### DIFF
--- a/chart/templates/postgres-secret.yaml
+++ b/chart/templates/postgres-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gitlab-postgres
-  namespace: gitlab
+  namespace: {{ .Release.Namespace }}
 type: kubernetes.io/opaque
 stringData:
   password: {{ .Values.postgres.password }}

--- a/chart/templates/postgres-secret.yaml
+++ b/chart/templates/postgres-secret.yaml
@@ -1,0 +1,10 @@
+{{- if not .Values.postgres.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-postgres
+  namespace: gitlab
+type: kubernetes.io/opaque
+stringData:
+  password: {{ .Values.postgres.password }}
+{{- end }}

--- a/chart/templates/postgres-secret.yaml
+++ b/chart/templates/postgres-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.postgres.password }}
+{{- if ne .Values.postgres.password "" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,8 @@ redis:
   namespace: dev-redis
   port: 6379
 postgres:
+  password: ""
+
   # Set to false to use external postgres
   internal: true
   selector:


### PR DESCRIPTION
## Description

This allows for the Postgres password secret to be generated in the config chart directly

## Related Issue

Fixes #145 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
