### PR TITLE
chore!: remove egress anywhere for SSO

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -363,9 +363,11 @@ spec:
         description: "SSO Internal"
 
       - direction: Egress
-        remoteGenerated: Anywhere
-        selector:
-          app: webservice
+        remoteNamespace: istio-tenant-gateway
+        remoteSelector:
+          app: tenant-ingressgateway
+        selector: 
+          uds/network-access-gitlab: "true"
         port: 443
         description: "SSO External"
 

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -366,8 +366,8 @@ spec:
         remoteNamespace: istio-tenant-gateway
         remoteSelector:
           app: tenant-ingressgateway
-        selector: 
-          uds/network-access-gitlab: "true"
+        selector:
+          app: webservice
         port: 443
         description: "SSO External"
 


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> :warning: **BREAKING CHANGE** This is a breaking change that requires `uds-core` `v0.22.0` but locks down GitLab to have no `remoteGenerated: Anywhere` entries by default.

## Related Issue

Relates to https://github.com/defenseunicorns/uds-core/issues/558

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
