### PR TITLE
chore: swap to `openid-connect` instead of `_`

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -80,7 +80,7 @@ packages:
               description: "Boolean to enable or disable sso things"
               path: "sso.enabled"
             - name: GITLAB_SSO_PROTOCOL
-              description: "Protocol to use. Valid values are 'openid_connect' and 'saml'. Default value is 'saml'"
+              description: "Protocol to use. Valid values are 'openid-connect' and 'saml'. Default value is 'saml'"
               path: "sso.protocol"
             - name: GITLAB_ADMIN_GROUPS
               description: "Array of group names that grant admin role gitlab when saml protocol is active."
@@ -110,7 +110,7 @@ packages:
               description: "Boolean to enable or disable sso things"
               path: "global.appConfig.omniauth.enabled"
             - name: GITLAB_SSO_PROTOCOL
-              description: "Protocol to use. Valid values are 'openid_connect' and 'saml'. Default value is 'saml'"
+              description: "Protocol to use. Valid values are 'openid-connect' and 'saml'. Default value is 'saml'"
               path: "global.appConfig.omniauth.autoSignInWithProvider"
             - name: MIGRATIONS_RESOURCES
               description: "Gitlab Migrations Resources"

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,8 @@
+{{- $NOTICE := "\n=== NOTICE" -}}
+{{- $WARNING := "\n=== WARNING" -}}
+{{- $CRITICAL := "\n=== CRITICAL" -}}
+
+{{- if eq .Values.sso.protocol "openid_connect" }}
+{{ $NOTICE }}
+Setting `.sso.protocol` to `openid_connect` has been deprecated - please switch to using `openid-connect` instead
+{{- end }}

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gitlab
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if and (.Values.sso.enabled) (eq .Values.sso.protocol "openid_connect") }}
+  {{- if and (.Values.sso.enabled) (or (eq .Values.sso.protocol "openid_connect") (eq .Values.sso.protocol "openid-connect")) }}
   sso:
     - name: GitLab Login
       clientId: uds-swf-gitlab


### PR DESCRIPTION
## Description

Swap over to accept `openid-connect` instead of `openid_connect`.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
