### PR TITLE
revert: return to underscores for value of `openid_connect`

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -79,9 +79,6 @@ packages:
             - name: GITLAB_SSO_ENABLED
               description: "Boolean to enable or disable sso things"
               path: "sso.enabled"
-            - name: GITLAB_SSO_PROTOCOL
-              description: "Protocol to use. Valid values are 'openid-connect' and 'saml'. Default value is 'saml'"
-              path: "sso.protocol"
             - name: GITLAB_ADMIN_GROUPS
               description: "Array of group names that grant admin role gitlab when saml protocol is active."
               path: "sso.adminGroups"
@@ -89,12 +86,9 @@ packages:
               description: "Array of group names that are required for GitLab acess."
               path: "sso.requiredGroups"
           values:
-            # TODO: (@WSTARR) The below two overrides will no longer be needed after the next release
-            - path: redis.namespace
-              value: valkey
-            - path: redis.selector
-              value:
-                app.kubernetes.io/name: valkey
+            - path: sso.protocol
+              description: "Protocol to use. Valid values are 'openid-connect' and 'saml'. Default value is 'saml' (NOTE this takes an '-' for OIDC!)"
+              value: saml
         gitlab:
           values:
             - path: global.psql.host
@@ -105,13 +99,13 @@ packages:
               value: "gitlab.gitlab.pg-cluster.credentials.postgresql.acid.zalan.do"
             - path: global.redis.host
               value: valkey-master.valkey.svc.cluster.local
+            - path: "global.appConfig.omniauth.autoSignInWithProvider"
+              description: "Protocol to use. Valid values are 'openid_connect' and 'saml'. Default value is 'saml' (NOTE this takes an '_' for OIDC!)"
+              value: "saml"
           variables:
             - name: GITLAB_SSO_ENABLED
               description: "Boolean to enable or disable sso things"
               path: "global.appConfig.omniauth.enabled"
-            - name: GITLAB_SSO_PROTOCOL
-              description: "Protocol to use. Valid values are 'openid-connect' and 'saml'. Default value is 'saml'"
-              path: "global.appConfig.omniauth.autoSignInWithProvider"
             - name: MIGRATIONS_RESOURCES
               description: "Gitlab Migrations Resources"
               path: "gitlab.migrations.resources"

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -87,7 +87,7 @@ packages:
               path: "sso.requiredGroups"
           values:
             - path: sso.protocol
-              description: "Protocol to use. Valid values are 'openid-connect' and 'saml'. Default value is 'saml' (NOTE this takes an '-' for OIDC!)"
+              description: "Protocol to use. Valid values are 'openid_connect', 'oidc' and 'saml'. Default value is 'saml' (NOTE 'oidc' is not valid in autoSignInWithProvider!)"
               value: saml
         gitlab:
           values:
@@ -100,7 +100,7 @@ packages:
             - path: global.redis.host
               value: valkey-master.valkey.svc.cluster.local
             - path: "global.appConfig.omniauth.autoSignInWithProvider"
-              description: "Protocol to use. Valid values are 'openid_connect' and 'saml'. Default value is 'saml' (NOTE this takes an '_' for OIDC!)"
+              description: "Protocol to use. Valid values are 'openid_connect' and 'saml'. Default value is 'saml'"
               value: "saml"
           variables:
             - name: GITLAB_SSO_ENABLED

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -79,16 +79,15 @@ packages:
             - name: GITLAB_SSO_ENABLED
               description: "Boolean to enable or disable sso things"
               path: "sso.enabled"
+            - name: GITLAB_SSO_PROTOCOL
+              description: "Protocol to use. Valid values are 'openid_connect' and 'saml'. Default value is 'saml'"
+              path: "sso.protocol"
             - name: GITLAB_ADMIN_GROUPS
               description: "Array of group names that grant admin role gitlab when saml protocol is active."
               path: "sso.adminGroups"
             - name: GITLAB_REQUIRED_GROUPS
               description: "Array of group names that are required for GitLab acess."
               path: "sso.requiredGroups"
-          values:
-            - path: sso.protocol
-              description: "Protocol to use. Valid values are 'openid_connect', 'oidc' and 'saml'. Default value is 'saml' (NOTE 'oidc' is not valid in autoSignInWithProvider!)"
-              value: saml
         gitlab:
           values:
             - path: global.psql.host
@@ -99,13 +98,13 @@ packages:
               value: "gitlab.gitlab.pg-cluster.credentials.postgresql.acid.zalan.do"
             - path: global.redis.host
               value: valkey-master.valkey.svc.cluster.local
-            - path: "global.appConfig.omniauth.autoSignInWithProvider"
-              description: "Protocol to use. Valid values are 'openid_connect' and 'saml'. Default value is 'saml'"
-              value: "saml"
           variables:
             - name: GITLAB_SSO_ENABLED
               description: "Boolean to enable or disable sso things"
               path: "global.appConfig.omniauth.enabled"
+            - name: GITLAB_SSO_PROTOCOL
+              description: "Protocol to use. Valid values are 'openid_connect' and 'saml'. Default value is 'saml'"
+              path: "global.appConfig.omniauth.autoSignInWithProvider"
             - name: MIGRATIONS_RESOURCES
               description: "Gitlab Migrations Resources"
               path: "gitlab.migrations.resources"

--- a/bundle/uds-config.yaml
+++ b/bundle/uds-config.yaml
@@ -18,6 +18,7 @@ variables:
     GITLAB_PAGES_ENABLED: true
     GITLAB_REQUIRED_GROUPS: [] # ["/GitLab"]
     GITLAB_ADMIN_GROUPS: ["/GitLab Admin", "/UDS Core/Admin"]
+    GITLAB_SSO_PROTOCOL: saml
     # # Overrides for scaled down cluster for local dev and CI
     webservice_replicas: 1
     webservice_resources:

--- a/bundle/uds-config.yaml
+++ b/bundle/uds-config.yaml
@@ -18,7 +18,6 @@ variables:
     GITLAB_PAGES_ENABLED: true
     GITLAB_REQUIRED_GROUPS: [] # ["/GitLab"]
     GITLAB_ADMIN_GROUPS: ["/GitLab Admin", "/UDS Core/Admin"]
-    GITLAB_SSO_PROTOCOL: saml
     # # Overrides for scaled down cluster for local dev and CI
     webservice_replicas: 1
     webservice_resources:

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,8 +1,0 @@
-{{- $NOTICE := "\n=== NOTICE" -}}
-{{- $WARNING := "\n=== WARNING" -}}
-{{- $CRITICAL := "\n=== CRITICAL" -}}
-
-{{- if eq .Values.sso.protocol "openid_connect" }}
-{{ $NOTICE }}
-Setting `.sso.protocol` to `openid_connect` has been deprecated - please switch to using `openid-connect` instead
-{{- end }}

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gitlab
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if and (.Values.sso.enabled) (or (eq .Values.sso.protocol "openid_connect") (eq .Values.sso.protocol "openid-connect")) }}
+  {{- if and (.Values.sso.enabled) (or (eq .Values.sso.protocol "openid_connect") (eq .Values.sso.protocol "oidc")) }}
   sso:
     - name: GitLab Login
       clientId: uds-swf-gitlab

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gitlab
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if and (.Values.sso.enabled) (or (eq .Values.sso.protocol "openid_connect") (eq .Values.sso.protocol "oidc")) }}
+  {{- if and (.Values.sso.enabled) (eq .Values.sso.protocol "openid_connect") }}
   sso:
     - name: GitLab Login
       clientId: uds-swf-gitlab


### PR DESCRIPTION
## Description

This fixes the autosignin key docs since that must be an underscore `_`

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed

Refs: 59e3954