### PR TITLE
fix: update_secret_ownership

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -21,6 +21,8 @@ components:
           - ../values/common-values.yaml
     actions:
       onDeploy:
+        before:
+          - cmd: ./zarf tools kubectl annotate secret -n gitlab gitlab-postgres meta.helm.sh/release-name=uds-gitlab-config || true
         after:
           - description: Validate GitLab Package
             maxTotalSeconds: 300

--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -24,6 +24,8 @@ components:
         before:
           - cmd: ./zarf tools kubectl annotate --overwrite secret -n gitlab gitlab-postgres meta.helm.sh/release-name=uds-gitlab-config || true
           - cmd: ./zarf tools kubectl annotate --overwrite secret -n gitlab gitlab-postgres meta.helm.sh/release-namespace=gitlab || true
+          - cmd: ./zarf tools kubectl annotate --overwrite secret -n gitlab gitlab-redis meta.helm.sh/release-name=uds-gitlab-config || true
+          - cmd: ./zarf tools kubectl annotate --overwrite secret -n gitlab gitlab-redis meta.helm.sh/release-namespace=gitlab || true
         after:
           - description: Validate GitLab Package
             maxTotalSeconds: 300

--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -22,7 +22,8 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: ./zarf tools kubectl annotate secret -n gitlab gitlab-postgres meta.helm.sh/release-name=uds-gitlab-config || true
+          - cmd: ./zarf tools kubectl annotate --overwrite secret -n gitlab gitlab-postgres meta.helm.sh/release-name=uds-gitlab-config || true
+          - cmd: ./zarf tools kubectl annotate --overwrite secret -n gitlab gitlab-postgres meta.helm.sh/release-namespace=gitlab || true
         after:
           - description: Validate GitLab Package
             maxTotalSeconds: 300


### PR DESCRIPTION
## Description

If an existing secret existed from the old separate secret package pattern, gitlab will fail to deploy because of the ownership of the secret that was previously deployed outside of the gitlab package. this fixes that. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
