### PR TITLE
fix: add netpol to allow gitaly to perform repository mirroring actions

### DIFF
--- a/charts/config/templates/uds-package.yaml
+++ b/charts/config/templates/uds-package.yaml
@@ -445,6 +445,18 @@ spec:
         {{- end }}
         description: "Gitlab Pages Storage"
 
+      # Gitaly
+      - direction: Egress
+        selector:
+          app: gitaly
+        remoteGenerated: Anywhere
+        ports:
+          - 9418
+          - 443
+          - 80
+          - 22
+        description: Gitaly repository mirroring
+
       # Custom rules for unanticipated scenarios
       {{- range .Values.custom }}
       - direction: {{ .direction }}

--- a/charts/config/templates/uds-package.yaml
+++ b/charts/config/templates/uds-package.yaml
@@ -446,6 +446,7 @@ spec:
         description: "Gitlab Pages Storage"
 
       # Gitaly
+      {{ if .Values.mirroring.enabled }}
       - direction: Egress
         selector:
           app: gitaly
@@ -453,6 +454,7 @@ spec:
         ports:
           {{- .Values.mirroring.ports | toYaml | nindent 10 }}
         description: Gitaly repository mirroring
+      {{- end }}
 
       # Custom rules for unanticipated scenarios
       {{- range .Values.custom }}

--- a/charts/config/templates/uds-package.yaml
+++ b/charts/config/templates/uds-package.yaml
@@ -451,10 +451,7 @@ spec:
           app: gitaly
         remoteGenerated: Anywhere
         ports:
-          - 9418
-          - 443
-          - 80
-          - 22
+          {{- .Values.mirroring.ports | toYaml | nindent 10 }}
         description: Gitaly repository mirroring
 
       # Custom rules for unanticipated scenarios

--- a/charts/config/values.yaml
+++ b/charts/config/values.yaml
@@ -48,6 +48,16 @@ runner:
     app: gitlab-runner
   namespace: gitlab-runner
   sandboxNamespace: gitlab-runner-sandbox
+
+# Gitaly is responsible for mirroring actions, and there are 4 valid protocols with the following ports
+# ssh: 22
+# http: 80
+# https: 443
+# git: 9418
+mirroring:
+  ports:
+    - 443
+
 # custom:
 #    # Notice no `remoteGenerated` field here on custom internal rule
 #   - direction: Ingress

--- a/charts/config/values.yaml
+++ b/charts/config/values.yaml
@@ -55,6 +55,7 @@ runner:
 # https: 443
 # git: 9418
 mirroring:
+  enabled: false
   ports:
     - 443
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ Network policies are controlled via the `uds-gitlab-config` chart in accordance 
 - `storage`: sets network policies for accessing object storage from all GitLab services (`registry`, `pages`, `webservice`, `toolbox`, `sidekiq`)
 - `redis`:  sets network policies for accessing a Redis-compatible server from all GitLab services (`webservice`, `toolbox`, `sidekiq`, `migrations`, `gitlab-exporter`)
 - `postgres`: sets network policies for accessing a Postgres database from all GitLab services (`webservice`, `toolbox`, `sidekiq`, `migrations`, `gitlab-exporter`)
+- `mirroring`: sets network policies that allow the gitlab repository mirroring feature to work. It defaults to only `https` (443) but can be set to allow the other protocols gitlab supports via the `ports` key.
 - `custom`: sets custom network policies for the GitLab namespace - this allows for custom integrations with other services (i.e. Jira)
 
 > [!NOTE]


### PR DESCRIPTION
## Description

add netpol to allow gitaly to perform repository mirroring actions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
