### PR TITLE
fix: remove rate-limiting from default settings

### DIFF
--- a/charts/settings/values.yaml
+++ b/charts/settings/values.yaml
@@ -56,22 +56,16 @@ settingsJob:
     admin_mode: true
     notify_on_unknown_sign_in: true
     dns_rebinding_protection_enabled: true
-    throttle_authenticated_api_enabled: true
     throttle_authenticated_api_period_in_seconds: 3600
     throttle_authenticated_api_requests_per_period: 7200
-    throttle_authenticated_packages_api_enabled: true
     throttle_authenticated_packages_api_period_in_seconds: 3600
     throttle_authenticated_packages_api_requests_per_period: 7200
-    throttle_authenticated_web_enabled: true
     throttle_authenticated_web_period_in_seconds: 3600
     throttle_authenticated_web_requests_per_period: 7200
-    throttle_unauthenticated_api_enabled: true
     throttle_unauthenticated_api_period_in_seconds: 3600
     throttle_unauthenticated_api_requests_per_period: 3600
-    throttle_unauthenticated_packages_api_enabled: true
     throttle_unauthenticated_packages_api_period_in_seconds: 3600
     throttle_unauthenticated_packages_api_requests_per_period: 3600
-    throttle_unauthenticated_web_enabled: true
     throttle_unauthenticated_web_period_in_seconds: 3600
     throttle_unauthenticated_web_requests_per_period: 3600
     usage_ping_enabled: false


### PR DESCRIPTION
## Description

This removes rate limiting from the GitLab defaults as it will not be supported by `uds-core` by default at this time: https://github.com/defenseunicorns/uds-core/pull/984

## Related Issue

Fixes #N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
