### PR TITLE
fix: add docs and escape hatch for object storage generation

### DIFF
--- a/charts/config/values.yaml
+++ b/charts/config/values.yaml
@@ -25,7 +25,7 @@ storage:
   port: 9000
   endpoint: "http://uds-minio-hl.minio.svc.cluster.local:9000"
   createSecret:
-    enabled: true
+    enabled: "###ZARF_VAR_GENERATE_STORAGE_SECRET###"
     accessKey: ""
     secretKey: ""
     bucketPrefix: "###ZARF_VAR_BUCKET_PREFIX###"

--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -29,9 +29,12 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-namespace=gitlab --overwrite || true
-          - cmd: ./zarf tools kubectl label secret -n gitlab gitlab-object-store app.kubernetes.io/managed-by=Helm --overwrite || true
-          - cmd: ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-name=uds-gitlab-config --overwrite || true
+          - cmd: |
+          if [ "$ZARF_VAR_GENERATE_STORAGE_SECRET" == "true" ]; then
+            ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-namespace=gitlab --overwrite || true
+            ./zarf tools kubectl label secret -n gitlab gitlab-object-store app.kubernetes.io/managed-by=Helm --overwrite || true
+            ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-name=uds-gitlab-config --overwrite || true
+          fi
         after:
           - description: Validate GitLab Package
             maxTotalSeconds: 300

--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -30,11 +30,11 @@ components:
       onDeploy:
         before:
           - cmd: |
-          if [ "$ZARF_VAR_GENERATE_STORAGE_SECRET" == "true" ]; then
-            ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-namespace=gitlab --overwrite || true
-            ./zarf tools kubectl label secret -n gitlab gitlab-object-store app.kubernetes.io/managed-by=Helm --overwrite || true
-            ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-name=uds-gitlab-config --overwrite || true
-          fi
+              if [ "$ZARF_VAR_GENERATE_STORAGE_SECRET" == "true" ]; then
+                ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-namespace=gitlab --overwrite || true
+                ./zarf tools kubectl label secret -n gitlab gitlab-object-store app.kubernetes.io/managed-by=Helm --overwrite || true
+                ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-name=uds-gitlab-config --overwrite || true
+              fi
         after:
           - description: Validate GitLab Package
             maxTotalSeconds: 300

--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -30,7 +30,7 @@ components:
       onDeploy:
         before:
           - cmd: |
-              if [ "$ZARF_VAR_GENERATE_STORAGE_SECRET" == "true" ]; then
+              if [ "$ZARF_VAR_GENERATE_STORAGE_SECRET" = "true" ]; then
                 ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-namespace=gitlab --overwrite || true
                 ./zarf tools kubectl label secret -n gitlab gitlab-object-store app.kubernetes.io/managed-by=Helm --overwrite || true
                 ./zarf tools kubectl annotate secret -n gitlab gitlab-object-store meta.helm.sh/release-name=uds-gitlab-config --overwrite || true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,7 +107,7 @@ When configuring the GitLab to connect to S3 storage in AWS, it is assumed IRSA 
               path: gitlab.gitlab-pages.serviceAccount.annotations.irsa/role-arn
 ```
 
-With this override definition one can then provide the IAM Role ARNs to the deployment via either `--set` variables or via a `uds-config.yaml`.
+With this override definition one can then provide the IAM role ARNs to the deployment via either `--set` variables or via a `uds-config.yaml`.
 
 ## Redis / Valkey
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ Below are the list of buckets that need to be created before starting GitLab:
 
 By default, the application is configured to work with `uds-package-minio-operator` package, adding [these overrides](https://github.com/defenseunicorns/uds-package-gitlab/blob/e2eb77af77c58ed423289db761dee43d9e7f82e2/bundle/uds-bundle.yaml#L18-L45) to the operator to provision the object storage required by GitLab.
 
-If you are not using in-cluster MinIO, but rather are using an external cloud providers object storage, you have two options. You can either create an object storage secret manually and disable the or have the helm chart generate one for you based on a set of input values. 
+If you are not using in-cluster MinIO, but rather are using an external cloud providers object storage, you have two options. You can either create an object storage secret manually and disable the generation of the secret or have the helm chart generate one for you based on a set of input values. 
 
 > [!NOTE] 
 > If you would like to opt out of the in-chart secret generation process, you may disable it by setting the zarf variable GENERATE_STORAGE_SECRET to false. Then you can provide your own object store secret, named gitlab-object-store, as needed following GitLab's documentation.

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,6 +17,8 @@ variables:
     default: "uds-"
   - name: BUCKET_SUFFIX
     default: ""
+  - names: GENERATE_STORAGE_SECRET
+    default: "true"
   - name: GITLAB_REDIS_ENDPOINT
     default: ""
   - name: GITLAB_REDIS_SCHEME

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
     default: "uds-"
   - name: BUCKET_SUFFIX
     default: ""
-  - names: GENERATE_STORAGE_SECRET
+  - name: GENERATE_STORAGE_SECRET
     default: "true"
   - name: GITLAB_REDIS_ENDPOINT
     default: ""


### PR DESCRIPTION
## Description

- add docs for object storage generation
- add zarf var to facilitate manual secret creation without ownership ref issues

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
