### PR TITLE
fix: Apply defensive logic to createSecret.enabled flag

### DIFF
--- a/charts/config/templates/gitlab-object-store-secret.yaml
+++ b/charts/config/templates/gitlab-object-store-secret.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-{{- if .Values.storage.createSecret.enabled }}
+{{- if eq (lower .Values.storage.createSecret.enabled | toString) "true" }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## Description
Added defensive logic to only allow `TRUE`, `True` or `true` to enable the gitlab-object-store secret generation (defaults to "true" in the zarf package).

## Related Issue

Fixes #279 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
