### PR TITLE
chore(ci): fix scorecard permissions

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -25,6 +25,7 @@ jobs:
       issues: read
       packages: read
       pages: read
+      models: read
       pull-requests: read
       repository-projects: read
       statuses: read


### PR DESCRIPTION
## Description

Resolve error due to workflow permissions:
```
Invalid workflow file: .github/workflows/scorecard.yaml#L17
The workflow is not valid. .github/workflows/scorecard.yaml (Line: 17, Col: 3): Error calling workflow 'defenseunicorns/uds-common/.github/workflows/callable-scorecard.yaml@42196a596353dc9f8acb21a6a86b5d4a4f7ee76f'. The workflow is requesting 'models: read', but is only allowed 'models: none'.
```

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
