### PR TITLE
chore: switch workhorse renovate to docker versioning to preserve suffix

### DIFF
--- a/values/unicorn-values.yaml
+++ b/values/unicorn-values.yaml
@@ -8,7 +8,7 @@ gitlab:
       tag: v18.0.1-fips
     workhorse:
       image: registry.gitlab.com/gitlab-org/build/cng/gitlab-workhorse-ee
-      # renovate: datasource=docker depName=registry.gitlab.com/gitlab-org/build/cng/gitlab-workhorse-ee versioning=semver
+      # renovate: datasource=docker depName=registry.gitlab.com/gitlab-org/build/cng/gitlab-workhorse-ee versioning=docker
       tag: v18.0.1-fips
   sidekiq:
     image:

--- a/values/upstream-values.yaml
+++ b/values/upstream-values.yaml
@@ -8,7 +8,7 @@ gitlab:
       tag: v18.0.1-fips
     workhorse:
       image: registry.gitlab.com/gitlab-org/build/cng/gitlab-workhorse-ee
-      # renovate: datasource=docker depName=registry.gitlab.com/gitlab-org/build/cng/gitlab-workhorse-ee versioning=semver
+      # renovate: datasource=docker depName=registry.gitlab.com/gitlab-org/build/cng/gitlab-workhorse-ee versioning=docker
       tag: v18.0.1-fips
   sidekiq:
     image:


### PR DESCRIPTION
## Description

switch workhorse renovate comment to docker versioning so the -fips doesnt get dropped

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
