### PR TITLE
feat: allow for gitlab gateways to be configurable

### DIFF
--- a/charts/config/templates/uds-package.yaml
+++ b/charts/config/templates/uds-package.yaml
@@ -7,6 +7,7 @@ metadata:
   name: gitlab
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- $ssoDomain := ternary (trimPrefix "admin." .Values.domain) .Values.domain (eq .Values.gateway "admin") }}
   {{- if and (.Values.sso.enabled) (eq .Values.sso.protocol "openid_connect") }}
   sso:
     - name: GitLab Login
@@ -41,7 +42,7 @@ spec:
                 "profile"
               ],
               "response_type": "code",
-              "issuer": "https://sso.{{ .Values.domain }}/realms/uds",
+              "issuer": "https://sso.{{ $ssoDomain }}/realms/uds",
               "client_auth_method": "query",
               "discovery": false,
               "uid_field": "preferred_username",
@@ -51,9 +52,9 @@ spec:
                 "secret": "clientField(secret)",
                 "redirect_uri": "clientField(redirectUris)[0]",
                 "end_session_endpoint": "http://keycloak-http.keycloak.svc.cluster.local:8080/realms/uds/protocol/openid-connect/logout",
-                "authorization_endpoint": "https://sso.{{ .Values.domain }}/realms/uds/protocol/openid-connect/auth",
+                "authorization_endpoint": "https://sso.{{ $ssoDomain }}/realms/uds/protocol/openid-connect/auth",
                 "token_endpoint": "http://keycloak-http.keycloak.svc.cluster.local:8080/realms/uds/protocol/openid-connect/token",
-                "userinfo_endpoint": "https://sso.{{ .Values.domain }}/realms/uds/protocol/openid-connect/userinfo",
+                "userinfo_endpoint": "https://sso.{{ $ssoDomain }}/realms/uds/protocol/openid-connect/userinfo",
                 "jwks_uri": "http://keycloak-http.keycloak.svc.cluster.local:8080/realms/uds/protocol/openid-connect/certs"
               }
             }
@@ -134,7 +135,7 @@ spec:
             "args":{
                 "assertion_consumer_service_url": "https://gitlab.{{ .Values.domain }}/users/auth/saml/callback",
                 "idp_cert": "clientField(samlIdpCertificate)",
-                "idp_sso_target_url": "https://sso.{{ .Values.domain }}/realms/uds/protocol/saml",
+                "idp_sso_target_url": "https://sso.{{ $ssoDomain }}/realms/uds/protocol/saml",
                 "issuer": "clientField(clientId)",
                 "name_identifier_format": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
             }
@@ -148,19 +149,19 @@ spec:
         selector:
           app: webservice
         host: gitlab
-        gateway: tenant
+        gateway: {{ .Values.gateway }}
         port: 8181
       - service: gitlab-gitlab-pages
         selector:
           app: gitlab-pages
         host: "*.pages"
-        gateway: tenant
+        gateway: {{ .Values.gateway }}
         port: 8090
       - service: gitlab-registry
         selector:
           app: registry
         host: registry
-        gateway: tenant
+        gateway: {{ .Values.gateway }}
         port: 5000
     allow:
       - direction: Ingress
@@ -170,9 +171,9 @@ spec:
       - direction: Ingress
         selector:
           app: gitlab-shell
-        remoteNamespace: istio-tenant-gateway
+        remoteNamespace: istio-{{ .Values.gateway }}-gateway
         remoteSelector:
-          app: tenant-ingressgateway
+          app: {{ .Values.gateway }}-ingressgateway
         port: 2222
         description: "SSH Ingress"
     {{- end }}
@@ -453,9 +454,9 @@ spec:
         description: "SSO Internal"
 
       - direction: Egress
-        remoteNamespace: istio-tenant-gateway
+        remoteNamespace: istio-{{ .Values.gateway }}-gateway
         remoteSelector:
-          app: tenant-ingressgateway
+          app: {{ .Values.gateway }}-ingressgateway
         selector:
           app: webservice
         port: 443

--- a/charts/config/values.schema.json
+++ b/charts/config/values.schema.json
@@ -5,6 +5,13 @@
       "domain": {
         "type": "string"
       },
+      "gateway": {
+        "type": "string",
+        "enum": [
+          "tenant",
+          "admin"
+        ]
+      },
       "license": {
         "type": "string"
       },

--- a/charts/config/values.yaml
+++ b/charts/config/values.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 # yaml-language-server: $schema=./values.schema.json
 
-domain: "###ZARF_VAR_DOMAIN###"
+domain: uds.dev # replace by '###ZARF_VAR_DOMAIN###' in package
+gateway: tenant # options are 'tenant' or 'admin', controls which gateway gitlab is exposed through
 
 # contents of a gitlab license, if available
 license: ""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,16 @@ Network policies are controlled via the `uds-gitlab-config` chart in accordance 
 > [!NOTE]
 > Currently the GitLab UDS Package contains Istio `PeerAuthentication` exceptions to allow the `dependency` init containers to reach out and check the Redis and Postgres services.  These are only added with `redis.internal` or `postgres.internal` set to `true` and will be removed once UDS Core [switches to native sidecars](https://github.com/defenseunicorns/uds-core/issues/536).
 
+
+### Gateway configuration
+
+By default, gitlab is exposed through the tenant gateway which puts it at `gitlab.domain.com`. If you would rather have gitlab exposed on the admin gateway (`gitlab.admin.domain.com`), there is a value that can be overridden within the `uds-gitlab-config` chart. 
+
+#### `uds-gitlab-config` chart:
+
+- `gateway` - can be set to `admin` or the default value `tenant`
+
+
 ## Database
 
 GitLab uses Postgres as its backing database service and supports the [common database providers within UDS Software Factory](https://github.com/defenseunicorns/uds-software-factory/blob/main/docs/database.md).  

--- a/values/config-values.yaml
+++ b/values/config-values.yaml
@@ -1,6 +1,8 @@
 # Copyright 2025 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
+domain: "###ZARF_VAR_DOMAIN###"
+
 storage:
   createSecret:
     enabled: "###ZARF_VAR_GENERATE_STORAGE_SECRET###"


### PR DESCRIPTION
## Description

The gateway has been historically hardcoded for tenant exposure. In order to facilitate the need for exposing gitlab through other gateways (admin only for now), make it configurable while defaulting to tenant. 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
