### PR TITLE
fix: add missing arm artifact on unicorn flavor

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,6 @@ jobs:
         exclude:
           - flavor: registry1
             architecture: arm64
-          - flavor: unicorn
-            architecture: arm64
     uses: defenseunicorns/uds-common/.github/workflows/callable-publish.yaml@f38e2d9595351ba8f9455f201a66eb91ccd039f2 # v1.20.3
     with:
       flavor: ${{ matrix.flavor }}

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -10,4 +10,4 @@ flavors:
     version: 18.4.1-uds.0
   - name: unicorn
     # renovate-uds: datasource=docker depName=registry.gitlab.com/gitlab-org/build/cng/gitlab-base extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 18.4.1-uds.0
+    version: 18.4.1-uds.1


### PR DESCRIPTION
## Description

arm64 release was being omitted in workflows for unicorn flavor. This adds it back and triggers release.
